### PR TITLE
CutsceneCharacter + misc fixes

### DIFF
--- a/art/readme.txt
+++ b/art/readme.txt
@@ -79,7 +79,7 @@ Final important thing, this is made with the support and love to and from Newgro
 Go to newgrounds, we love newgrounds. newgrounds good. How many times do I gotta damn say it. Newgrounds newgrounds newgrounds newgrounds
 I love Tom Fulp.
 
-- Cameron â™ª(Â´â–½ï½€)
+- Cameron ♪(´▽｀)
 
 ##################################################################################
                                                                                   

--- a/source/CutsceneCharacter.hx
+++ b/source/CutsceneCharacter.hx
@@ -71,6 +71,7 @@ class CutsceneCharacter extends FlxTypedGroup<Dynamic>
 				ended();
 			}
 		};
+		add(spr);
 	}
 
 	function ended()

--- a/source/CutsceneCharacter.hx
+++ b/source/CutsceneCharacter.hx
@@ -28,7 +28,7 @@ class CutsceneCharacter extends FlxTypedGroup<Dynamic>
 
 	function parseOffsets()
 	{
-		var swag:Array<String> = CoolUtil.coolTextFile(Paths.file('images/cutsceneStuff/' + imageShit + 'CutscenOffsets.txt'));
+		var swag:Array<String> = CoolUtil.coolTextFile(Paths.file('images/cutsceneStuff/' + imageShit + 'CutsceneOffsets.txt'));
 		for (stuff in swag)
 		{
 			var point:FlxPoint = FlxPoint.get();

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -982,7 +982,7 @@ class PlayState extends MusicBeatState
 		new FlxVideo('music/ughCutscene.mp4').finishCallback = function()
 		{
 			remove(black);
-			FlxTween.tween(FlxG.camera, {zoom: defaultCamZoom}, (Conductor.stepCrochet / 1000) * 5, {ease: FlxEase.quadInOut});
+			FlxTween.tween(FlxG.camera, {zoom: defaultCamZoom}, (Conductor.crochet / 1000) * 5, {ease: FlxEase.quadInOut});
 			startCountdown();
 			cameraMovement();
 		};
@@ -1000,7 +1000,7 @@ class PlayState extends MusicBeatState
 		new FlxVideo('music/gunsCutscene.mp4').finishCallback = function()
 		{
 			remove(black);
-			FlxTween.tween(FlxG.camera, {zoom: defaultCamZoom}, (Conductor.stepCrochet / 1000) * 5, {ease: FlxEase.quadInOut});
+			FlxTween.tween(FlxG.camera, {zoom: defaultCamZoom}, (Conductor.crochet / 1000) * 5, {ease: FlxEase.quadInOut});
 			startCountdown();
 			cameraMovement();
 		};
@@ -1015,7 +1015,7 @@ class PlayState extends MusicBeatState
 		new FlxVideo('music/stressCutscene.mp4').finishCallback = function()
 		{
 			remove(black);
-			FlxTween.tween(FlxG.camera, {zoom: defaultCamZoom}, (Conductor.stepCrochet / 1000) * 5, {ease: FlxEase.quadInOut});
+			FlxTween.tween(FlxG.camera, {zoom: defaultCamZoom}, (Conductor.crochet / 1000) * 5, {ease: FlxEase.quadInOut});
 			startCountdown();
 			cameraMovement();
 		};


### PR DESCRIPTION
This PR fixes a file name error and a missing add in CutsceneCharacter.

Original JavaScript (run through pretty print) for reference:
 ```js
 parseOffsets: function() {
	for (var a = Mb.coolTextFile(H.getPath("images/cutsceneStuff/" + this.imageShit + "CutsceneOffsets.txt", "TEXT", null)), b = 0; b < a.length;) {
		var c = a[b];
		++b;
		var d = X._pool.get().set(0, 0);
		d._inPool = !1;
		var e = L.trim(c.split("---")[1]).split(" ");
		Ma.trace("cool split: " + c.split("---")[1], {
			fileName: "source/CutsceneCharacter.hx",
			lineNumber: 38,
			className: "CutsceneCharacter",
			methodName: "parseOffsets"
		});
		Ma.trace(e, {
			fileName: "source/CutsceneCharacter.hx",
			lineNumber: 39,
			className: "CutsceneCharacter",
			methodName: "parseOffsets"
		});
		d.set(parseFloat(e[0]), parseFloat(e[1]));
		e = this.animShit;
		var f = L.trim(c.split("---")[0]);
		e.h[f] = d;
		this.arrayLMFAOOOO.push(L.trim(c.split("---")[0]))
	}
	Ma.trace(null == this.animShit ? "null" : ba.stringify(this.animShit.h), {
		fileName: "source/CutsceneCharacter.hx",
		lineNumber: 46,
		className: "CutsceneCharacter",
		methodName: "parseOffsets"
	})
},
 createCutscene: function(a) {
	null == a && (a = 0);
	var b = this,
		c = new C(this.coolPos.x + this.animShit.h[this.arrayLMFAOOOO[a]].x, this.coolPos.y + this.animShit.h[this.arrayLMFAOOOO[a]].y),
		d = "cutsceneStuff/" + this.imageShit + "-" + a;
	c.set_frames(Ea.fromSparrow(H.getPath("images/" + d + ".png", "IMAGE", null), H.getPath("images/" + d + ".xml", "TEXT", null)));
	c.animation.addByPrefix("weed", this.arrayLMFAOOOO[a], 24, !1);
	c.animation.play("weed");
	c.set_antialiasing(!0);
	c.animation.finishCallback = function(d) {
		c.kill();
		c.destroy();
		c = null;
		a + 1 < b.arrayLMFAOOOO.length ? b.createCutscene(a + 1) : b.ended()
	};
	this.add(c)
},
```

This also fixes the broken encoding in the readme file, and the Week 7 intros using stepCrochet instead of crochet for the camera tween.

 Original JavaScript (run through pretty print) for reference:
 ```js
ughIntro: function() {
	var a = this;
	this.inCutscene = !0;
	var b = (new C(-200, -200)).makeGraphic(2 * k.width, 2 * k.height, -16777216);
	b.scrollFactor.set();
	this.add(b);
	(new Dh("music/ughCutscene.mp4")).finishCallback =
		function() {
			a.remove(b);
			db.tween(k.camera, {
				zoom: a.defaultCamZoom
			}, Z.crochet / 1E3 * 5, {
				ease: Rb.quadInOut
			});
			a.startCountdown();
			a.cameraMovement()
		};
	k.camera.set_zoom(1.2 * this.defaultCamZoom);
	var c = this.camFollow;
	c.set_x(c.x + 100);
	c = this.camFollow;
	c.set_y(c.y + 100)
},
gunsIntro: function() {
	var a = this;
	this.inCutscene = !0;
	var b = (new C(-200, -200)).makeGraphic(2 * k.width, 2 * k.height, -16777216);
	b.scrollFactor.set();
	this.add(b);
	(new Dh("music/gunsCutscene.mp4")).finishCallback = function() {
		a.remove(b);
		db.tween(k.camera, {
			zoom: a.defaultCamZoom
		}, Z.crochet / 1E3 * 5, {
			ease: Rb.quadInOut
		});
		a.startCountdown();
		a.cameraMovement()
	}
},
stressIntro: function() {
	var a = this;
	this.inCutscene = !0;
	var b = (new C(-200, -200)).makeGraphic(2 * k.width, 2 * k.height, -16777216);
	b.scrollFactor.set();
	this.add(b);
	(new Dh("music/stressCutscene.mp4")).finishCallback = function() {
		a.remove(b);
		db.tween(k.camera, {
			zoom: a.defaultCamZoom
		}, Z.crochet / 1E3 * 5, {
			ease: Rb.quadInOut
		});
		a.startCountdown();
		a.cameraMovement()
	}
},
```