### PR TITLE
Implement TankCutscene from an earlier v0.2.8 build

### DIFF
--- a/source/TankCutscene.hx
+++ b/source/TankCutscene.hx
@@ -1,0 +1,28 @@
+package;
+
+import flixel.FlxSprite;
+import flixel.system.FlxSound;
+
+class TankCutscene extends FlxSprite
+{
+	public var startSyncAudio:FlxSound;
+
+	var startedPlayingSound:Bool;
+
+	override public function new(x:Float = 0, y:Float = 0)
+	{
+		startedPlayingSound = false;
+		super(x, y);
+	}
+
+	override public function update(elapsed:Float)
+	{
+		if (animation.curAnim.curFrame <= 1 && !startedPlayingSound)
+		{
+			startSyncAudio.play();
+			startedPlayingSound = true;
+		}
+
+		super.update(elapsed);
+	}
+}


### PR DESCRIPTION
This is from an earlier build of v0.2.8 that was initially published to Newgrounds, infamous for crashing when starting Ugh in Story Mode due to trying to load missing cutscene assets instead of just... playing the video.

Original JavaScript (run through pretty print) for reference:
```js
var Zj = function(a, b) {
	this.startedPlayingSound = !1;
	y.call(this, a, b)
};
g.TankCutscene = Zj;
Zj.__name__ = "TankCutscene";
Zj.__super__ = y;
Zj.prototype = r(y.prototype, {
	update: function(a) {
		1 <= this.animation._curAnim.curFrame && !this.startedPlayingSound && (this.startSyncAudio.play(), this.startedPlayingSound = !0);
		y.prototype.update.call(this, a)
	},
	__class__: Zj
});
```

I was initially gonna include this with the other PR but I'm unsure of your stance with whether or not to exclusively port over the latest NG version.